### PR TITLE
fix a bug when spaces between tags don't let prettify the dom tree and cause wrong tags parsing

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -76,7 +76,7 @@ function createTreeFromHTML (code) {
   }
 
   // Fix for minified code
-  code = code.replace(/></g, `>\n<`);
+  code = code.replace(/> </g, `>\n<`);
 
   bodyClass = getTagClass(code);
   htmlClass = getTagClass(code, `html`);
@@ -468,7 +468,7 @@ function getTagClass (code, tagName = `body`) {
 
 // eslint-disable-next-line no-unused-vars
 function runDev () {
-  const testMarkup = `<html class="page"><body class="page__body"><h1 class="page__title">Title</h1><div class="wrapper"><section class="prices1"><div><h2 class="prices__title">Title</h2><div class="prices__content prices__content--disabled">Content</div></div></section><section class="reviews"><div><h2 class="reviews__title">Title</h2><div class="reviews__content">Content</div></div></section><footer class="footer"><div><h2 class="footer__title">Footer Title</h2><div class="footer__content"><h4 class="footer__subtitle">Footer SubTitle</h4>Footer Content</div></div></footer></div></div></body></html>`;
+  const testMarkup = `<html class="page"> <body class="page__body"><h1 class="page__title">Title</h1><div class="wrapper"><section class="prices1"><div><h2 class="prices__title">Title</h2><div class="prices__content prices__content--disabled">Content</div></div></section><section class="reviews"><div><h2 class="reviews__title">Title</h2><div class="reviews__content">Content</div></div></section><footer class="footer"><div><h2 class="footer__title">Footer Title</h2><div class="footer__content"><h4 class="footer__subtitle">Footer SubTitle</h4>Footer Content</div></div></footer></div></div></body></html>`;
   codeInput.value = testMarkup;
   setHeadersDefs();
   hasBemWarning = false;


### PR DESCRIPTION
Sometimes code with left spaces isn't parsed correctly. For example, 
`<body class="body"> <div class="block block--test">text</div></body>`

Since we don't care about the text nodes (only tag ones), we can just replace all the spaces between tags with line breaks as well.